### PR TITLE
ci: Add basic mkdocs github action

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: pip install -U mkdocs mkdocs-material
+        run: pip install -U mkdocs mkdocs-material mkdocs-glightbox
 
       - name: Generate resources.md files
         run: ./scripts/generate-resources

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,53 @@
+name: Build site with MkDocs and deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Format and build with MkDocs
+    runs-on: ubuntu-lates
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -U mkdocs mkdocs-material
+
+      - name: Generate resources.md files
+        run: ./scripts/generate-resources
+
+      - name: Build with MkDocs
+        run: mkdocs build
+
+      - name: Set up GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.geployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Uses `actions@setup-python@v5` for python installation.
  - Caches pip dependencies
- Installs the `mkdocs` and `mkdocs-material` modules (more can be added as needed).
- Generates `resources.md` pages in each book's subdirectory with the `generate-resources` script
- Builds with `mkdocs build`
- Uploads the resulting `./site` directory as an artifact for GH pages

This is just the skeleton. Can be optimized later.