### PR TITLE
fix: Markdown table not rendering properly when inside div

### DIFF
--- a/docs/lac/u1ws.md
+++ b/docs/lac/u1ws.md
@@ -44,8 +44,6 @@ could be transposed to a `.md` file.
 
 Using a 0-10 system, rate yourself on how well you think you know each topic in the table below. (You do not have to post this rating).
 
-<div style="display: flex; justify-content: left;">
-
 |   Skill    | High (8-10) | Mid (4-7) | Low (0-3) | Total |
 | :--------: | :---------: | :-------: | :-------: | :---: |
 |   Linux    |             |           |           |       |
@@ -59,8 +57,6 @@ Using a 0-10 system, rate yourself on how well you think you know each topic in 
 |   Cloud    |             |           |           |       |
 | Kubernetes |             |           |           |       |
 |   Total    |             |           |           |       |
-
-</div>
 
 Next, answer these questions here:
 


### PR DESCRIPTION
The markdown table in lac/u1ws.md is not rendering properly due to being wrapped in a raw HTML div. This patch just removes the surrounding `<div>`.

Closes #19 