### PR TITLE
fix: Typo in URL var, rename workflow file for clarity

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -44,7 +44,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ steps.geployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Fix the typo in the workflow file.
Rename the workflow file for clarity, since mkdocs.yml is also the name of the root mkdocs config.