### PR TITLE
refactor: Translate all HTML headers to markdown

### DIFF
--- a/docs/certify.md
+++ b/docs/certify.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Qualifying for the Certification</h1>
-    </p>
-</div>
+# Qualifying for the Certification
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Contributing to the ProLUG Linux Sysadmin Course Book</h1>
-    </p>
-</div>
+# Contributing to the ProLUG Linux Sysadmin Course Book
 
 The Professional Linux Users Group (ProLUG) provides a set of requirements
 and guidelines to contribute to this project. Below are steps to ensure

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Contributors</h1>
-    </p>
-</div>
+# Contributors
 
 This book was made possible by a small group of dedicated contributors who worked diligently to create an accessible resource for future students enrolled in courses offered by the Professional Linux User Group.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Contributing and Local Development</h1>
-    </p>
-</div>
+# Contributing and Local Development
 
 It is strongly encouraged that contributors test their changes before making
 commits. To help facilitate this process a set of instructions and guidelines

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
-# The Professional Linux Users Group (ProLUG)
-
-<div class="grid cards" markdown>
-
--   :material-account-group:{ .lg .middle } __ProLUG__
 
     ---
 

--- a/docs/lac/downloads.md
+++ b/docs/lac/downloads.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Course Work Downloads</h1>
-    </p>
-</div>
+# Course Work Downloads
 This page contains the downloads for all labs and worksheets in this course.  
 
 ## Unit 1

--- a/docs/lac/outro.md
+++ b/docs/lac/outro.md
@@ -1,6 +1,1 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Under Construction</h1>
-    </p>
-</div>
+# Under Construction

--- a/docs/lac/project.md
+++ b/docs/lac/project.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Final Project Outline</h1>
-    </p>
-</div>
+# Final Project Outline
 
 Students aiming to complete the Linux Systems Administration course are expected to
 devise and complete a capstone project, to be turned in at the end of the course.

--- a/docs/lac/resources.md
+++ b/docs/lac/resources.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Resources</h1>
-    </p>
-</div>
+# Resources
 
 This file is dynamically generated at build time using GitHub Actions.  
 

--- a/docs/lac/syllabus.md
+++ b/docs/lac/syllabus.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>ProLUG Systems Administration for the Enterprise</h1>
-    </p>
-</div>
 
 Welcome to the ProLUG Enterprise Linux Systems Administration Course Book.
 

--- a/docs/lac/u10b.md
+++ b/docs/lac/u10b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 10 Bonus - Kubernetes</h1>
-    </p>
-</div>
+# Unit 10 Bonus - Kubernetes
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u10intro.md
+++ b/docs/lac/u10intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 10 - Kubernetes</h1>
-    </p>
-</div>
+# Unit 10 - Kubernetes
 
 ## Overview
 

--- a/docs/lac/u10lab.md
+++ b/docs/lac/u10lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 10 Lab - Kubernetes</h1>
-    </p>
-</div>
+# Unit 10 Lab - Kubernetes
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u10ws.md
+++ b/docs/lac/u10ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 10 Worksheet - Kubernetes</h1>
-    </p>
-</div>
+# Unit 10 Worksheet - Kubernetes
 
 ## Instructions
 

--- a/docs/lac/u11intro.md
+++ b/docs/lac/u11intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 11 - Monitoring</h1>
-    </p>
-</div>
+# Unit 11 - Monitoring
 
 ## Overview
 

--- a/docs/lac/u11lab.md
+++ b/docs/lac/u11lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 11 Lab - Monitoring</h1>
-    </p>
-</div>
+# Unit 11 Lab - Monitoring
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u11ws.md
+++ b/docs/lac/u11ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 11 Worksheet - Monitoring</h1>
-    </p>
-</div>
+# Unit 11 Worksheet - Monitoring
 
 ## Instructions
 

--- a/docs/lac/u12intro.md
+++ b/docs/lac/u12intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-    <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 12 - Baselines & Benchmarks</h1>
-    </p>
-</div>
+# Unit 12 - Baselines & Benchmarks
 
 ## Overview
 

--- a/docs/lac/u12lab.md
+++ b/docs/lac/u12lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 12 Lab - Baselines & Benchmarks</h1>
-    </p>
-</div>
+# Unit 12 Lab - Baselines & Benchmarks
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u12ws.md
+++ b/docs/lac/u12ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 12 Worksheet - Baselines & Benchmarks</h1>
-    </p>
-</div>
+# Unit 12 Worksheet - Baselines & Benchmarks
 
 ## Instructions
 

--- a/docs/lac/u13b.md
+++ b/docs/lac/u13b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 13 Bonus - Hardening SSH and NGINX with Fail2Ban</h1>
-    </p>
-</div>
+# Unit 13 Bonus - Hardening SSH and NGINX with Fail2Ban
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u13intro.md
+++ b/docs/lac/u13intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-    <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 13 - System Hardening</h1>
-    </p>
-</div>
+# Unit 13 - System Hardening
 
 ## Overview
 

--- a/docs/lac/u13lab.md
+++ b/docs/lac/u13lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 13 Lab - System Hardening</h1>
-    </p>
-</div>
+# Unit 13 Lab - System Hardening
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u13ws.md
+++ b/docs/lac/u13ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 13 Worksheet - System Hardening</h1>
-    </p>
-</div>
+# Unit 13 Worksheet - System Hardening
 
 ## Instructions
 

--- a/docs/lac/u14b.md
+++ b/docs/lac/u14b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 14 Bonus Lab - Ansible + Automation Challenge
-</h1>
-    </p>
 </div>
 
 ## Objective

--- a/docs/lac/u14intro.md
+++ b/docs/lac/u14intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-    <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 14 - Ansible Automation</h1>
-    </p>
-</div>
+# Unit 14 - Ansible Automation
 
 ## Overview
 

--- a/docs/lac/u14lab.md
+++ b/docs/lac/u14lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 14 Lab - Ansible Automation</h1>
-    </p>
-</div>
+# Unit 14 Lab - Ansible Automation
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u14ws.md
+++ b/docs/lac/u14ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 14 Worksheet - Ansible Automation</h1>
-    </p>
-</div>
+# Unit 14 Worksheet - Ansible Automation
 
 ## Instructions
 

--- a/docs/lac/u15intro.md
+++ b/docs/lac/u15intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-    <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 15 - Engineering Troubleshooting</h1>
-    </p>
-</div>
+# Unit 15 - Engineering Troubleshooting
 
 ## Overview
 

--- a/docs/lac/u15lab.md
+++ b/docs/lac/u15lab.md
@@ -1,8 +1,3 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 15 Lab - Engineering Troubleshooting</h1>
-    </p>
-</div>
+# Unit 15 Lab - Engineering Troubleshooting
 
 ## No lab for unit 15. Work on your [projects](./project.md).

--- a/docs/lac/u15ws.md
+++ b/docs/lac/u15ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 15 Worksheet - Engineering Troubleshooting</h1>
-    </p>
-</div>
+# Unit 15 Worksheet - Engineering Troubleshooting
 
 ## Instructions
 

--- a/docs/lac/u16intro.md
+++ b/docs/lac/u16intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 16 - Incident Response</h1>
-    </p>
-</div>
+# Unit 16 - Incident Response
 
 ## Overview
 

--- a/docs/lac/u16lab.md
+++ b/docs/lac/u16lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 16 Lab - Incident Response</h1>
-    </p>
-</div>
+# Unit 16 Lab - Incident Response
 
 The unit 16 lab will be done during the lecture. Students will troubleshoot problems
 on systems in the ProLUG lab environment.

--- a/docs/lac/u16ws.md
+++ b/docs/lac/u16ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 16 Worksheet - Incident Response</h1>
-    </p>
-</div>
+# Unit 16 Worksheet - Incident Response
 
 ## Instructions
 

--- a/docs/lac/u1b.md
+++ b/docs/lac/u1b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 1 Bonus - VIM Fundamentals for Linux Sysadmins</h1>
-    </p>
-</div>
+# Unit 1 Bonus - VIM Fundamentals for Linux Sysadmins
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u1intro.md
+++ b/docs/lac/u1intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 1 - Linux File Operations</h1>
-    </p>
-</div>
 
 ## Overview
 

--- a/docs/lac/u1lab.md
+++ b/docs/lac/u1lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 1 Lab - Linux File Operations</h1>
-    </p>
-</div>
+# Unit 1 Lab - Linux File Operations
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u1ws.md
+++ b/docs/lac/u1ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 1 Worksheet - Linux File Operations</h1>
-    </p>
-</div>
+# Unit 1 Worksheet - Linux File Operations
 
 ## Instructions
 

--- a/docs/lac/u2intro.md
+++ b/docs/lac/u2intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 2 - Essential Tools</h1>
-    </p>
-</div>
 
 ## Overview
 

--- a/docs/lac/u2lab.md
+++ b/docs/lac/u2lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 2 Lab - Essential Tools</h1>
-    </p>
-</div>
+# Unit 2 Lab - Essential Tools
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u2ws.md
+++ b/docs/lac/u2ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 2 Worksheet - Essential Tools</h1>
-    </p>
-</div>
+# Unit 2 Worksheet - Essential Tools
 
 ## Instructions
 

--- a/docs/lac/u3b.md
+++ b/docs/lac/u3b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-      <h1>Unit 3 Bonus - Storage</h1>
-    </p>
-</div>
+# Unit 3 Bonus - Storage
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u3intro.md
+++ b/docs/lac/u3intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 3 - LVM and Raid</h1>
-    </p>
-</div>
 
 ## Overview
 

--- a/docs/lac/u3lab.md
+++ b/docs/lac/u3lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 3 Lab - LVM and Raid</h1>
-    </p>
-</div>
+# Unit 3 Lab - LVM and Raid
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u3ws.md
+++ b/docs/lac/u3ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 3 Worksheet - LVM and Raid</h1>
-    </p>
-</div>
+# Unit 3 Worksheet - LVM and Raid
 
 ## Instructions
 

--- a/docs/lac/u4intro.md
+++ b/docs/lac/u4intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 4 - Operating Running Systems</h1>
-    </p>
-</div>
 
 ## Overview
 

--- a/docs/lac/u4lab.md
+++ b/docs/lac/u4lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 4 Lab - Operating Running Systems</h1>
-    </p>
-</div>
+# Unit 4 Lab - Operating Running Systems
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u4ws.md
+++ b/docs/lac/u4ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 4 Worksheet - Operating Running Systems</h1>
-    </p>
-</div>
+# Unit 4 Worksheet - Operating Running Systems
 
 ## Instructions
 

--- a/docs/lac/u5intro.md
+++ b/docs/lac/u5intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 5 Lab - Managing Users and Groups</h1>
-    </p>
-</div>
 
 ## Overview
 

--- a/docs/lac/u5lab.md
+++ b/docs/lac/u5lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 5 Lab - Managing Users and Groups</h1>
-    </p>
-</div>
+# Unit 5 Lab - Managing Users and Groups
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u5ws.md
+++ b/docs/lac/u5ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 5 Worksheet - Managing Users and Groups</h1>
-    </p>
-</div>
+# Unit 5 Worksheet - Managing Users and Groups
 
 ## Instructions
 

--- a/docs/lac/u6b.md
+++ b/docs/lac/u6b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 6 Bonus - Terminal Multiplexors</h1>
-    </p>
-</div>
+# Unit 6 Bonus - Terminal Multiplexors
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u6intro.md
+++ b/docs/lac/u6intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
         <h1>Unit 6 - Firewalls</h1>
-    </p>
-</div>
 
 ## Overview
 

--- a/docs/lac/u6lab.md
+++ b/docs/lac/u6lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 6 Lab - Firewalls</h1>
-    </p>
-</div>
+# Unit 6 Lab - Firewalls
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u6ws.md
+++ b/docs/lac/u6ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 6 Worksheet - Firewalls</h1>
-    </p>
-</div>
+# Unit 6 Worksheet - Firewalls
 
 ## Instructions
 

--- a/docs/lac/u7b.md
+++ b/docs/lac/u7b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 7 Bonus - Package Management & Patching</h1>
-    </p>
-</div>
+# Unit 7 Bonus - Package Management & Patching
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u7intro.md
+++ b/docs/lac/u7intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 7 - Package Management & Patching</h1>
-    </p>
-</div>
+# Unit 7 - Package Management & Patching
 
 ## Overview
 

--- a/docs/lac/u7lab.md
+++ b/docs/lac/u7lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 7 Lab - Package Management & Patching</h1>
-    </p>
-</div>
+# Unit 7 Lab - Package Management & Patching
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u7ws.md
+++ b/docs/lac/u7ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 7 Worksheet - Package Management & Patching</h1>
-    </p>
-</div>
+# Unit 7 Worksheet - Package Management & Patching
 
 ## Instructions
 

--- a/docs/lac/u8b.md
+++ b/docs/lac/u8b.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 8 Bonus - Scripting  </h1>
-    </p>
-</div>
+# Unit 8 Bonus - Scripting  
 
 > **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
 

--- a/docs/lac/u8intro.md
+++ b/docs/lac/u8intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 8 - Scripting</h1>
-    </p>
-</div>
+# Unit 8 - Scripting
 
 ## Overview
 

--- a/docs/lac/u8lab.md
+++ b/docs/lac/u8lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 8 Lab - Scripting</h1>
-    </p>
-</div>
+# Unit 8 Lab - Scripting
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u8ws.md
+++ b/docs/lac/u8ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 8 Worksheet - Scripting</h1>
-    </p>
-</div>
+# Unit 8 Worksheet - Scripting
 
 ## Instructions
 

--- a/docs/lac/u9intro.md
+++ b/docs/lac/u9intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 9 - Containerization on Linux</h1>
-    </p>
-</div>
+# Unit 9 - Containerization on Linux
 
 ## Overview
 

--- a/docs/lac/u9lab.md
+++ b/docs/lac/u9lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 9 Lab - Containerization on Linux</h1>
-    </p>
-</div>
+# Unit 9 Lab - Containerization on Linux
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/lac/u9ws.md
+++ b/docs/lac/u9ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
-        <h1>Unit 9 Worksheet - Containerization on Linux</h1>
-    </p>
-</div>
+# Unit 9 Worksheet - Containerization on Linux
 
 ## Instructions
 

--- a/docs/pcae/resources.md
+++ b/docs/pcae/resources.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Resources</h1>
-    </p>
-</div>
+# Resources
 
 This file is dynamically generated at build time using GitHub Actions.  
 

--- a/docs/psc/outro.md
+++ b/docs/psc/outro.md
@@ -1,6 +1,1 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Under Construction</h1>
-    </p>
-</div>
+# Under Construction

--- a/docs/psc/project.md
+++ b/docs/psc/project.md
@@ -1,9 +1,4 @@
-<head>
-    <style> .flex-container { display: flex; align-items: center; gap: 20px; } </style>
-</head>
 <div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
         <h1>ProLUG Security Engineering - Final Project</h1>
     </p>
 </div>

--- a/docs/psc/resources.md
+++ b/docs/psc/resources.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Resources</h1>
-    </p>
-</div>
+# Resources
 
 This file is dynamically generated at build time using GitHub Actions.  
 

--- a/docs/psc/syllabus.md
+++ b/docs/psc/syllabus.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>ProLUG Security Engineering Course</h1>
-    </p>
-</div>
+# ProLUG Security Engineering Course
 
 Welcome to the ProLUG Security Engineering Course Book.
 

--- a/docs/psc/u10intro.md
+++ b/docs/psc/u10intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 10 - Recap and Final Project</h1>
-    </p>
-</div>
+# Unit 10 - Recap and Final Project
 
 ## Overview
 

--- a/docs/psc/u10lab.md
+++ b/docs/psc/u10lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Under Construction</h1>
-    </p>
-</div>
+# Under Construction
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u10ws.md
+++ b/docs/psc/u10ws.md
@@ -1,9 +1,4 @@
-<head>
-    <style> .flex-container { display: flex; align-items: center; gap: 20px; } </style>
-</head>
 <div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
         <h1>Unit 10 Worksheet - Recap and Final Project</h1>
     </p>
 </div>

--- a/docs/psc/u1intro.md
+++ b/docs/psc/u1intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 1 - Build Standards and Compliance</h1>
-    </p>
-</div>
+# Unit 1 - Build Standards and Compliance
 
 ## Overview
 

--- a/docs/psc/u1lab.md
+++ b/docs/psc/u1lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 1 Lab - Build Standards and Compliance</h1>
-    </p>
-</div>
+# Unit 1 Lab - Build Standards and Compliance
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u1ws.md
+++ b/docs/psc/u1ws.md
@@ -1,9 +1,4 @@
-<head>
-    <style> .flex-container { display: flex; align-items: center; gap: 20px; } </style>
-</head>
 <div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
         <h1>Unit 1 Worksheet - Build Standards and Compliance</h1>
     </p>
 </div>

--- a/docs/psc/u2intro.md
+++ b/docs/psc/u2intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 2 - Securing the Network Connection</h1>
-    </p>
-</div>
+# Unit 2 - Securing the Network Connection
 
 ## Overview
 

--- a/docs/psc/u2lab.md
+++ b/docs/psc/u2lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 2 Lab - Securing the Network Connection</h1>
-    </p>
-</div>
+# Unit 2 Lab - Securing the Network Connection
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u2ws.md
+++ b/docs/psc/u2ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 2 Worksheet - Securing the Network Connection</h1>
-    </p>
-</div>
+# Unit 2 Worksheet - Securing the Network Connection
 
 ## Instructions
 

--- a/docs/psc/u3intro.md
+++ b/docs/psc/u3intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 3 - User Access and System Integration</h1>
-    </p>
-</div>
+# Unit 3 - User Access and System Integration
 
 ## Overview
 

--- a/docs/psc/u3lab.md
+++ b/docs/psc/u3lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 3 Lab - User Access and System Integration</h1>
-    </p>
-</div>
+# Unit 3 Lab - User Access and System Integration
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u3ws.md
+++ b/docs/psc/u3ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 3 Worksheet - User Access and System Integration</h1>
-    </p>
-</div>
+# Unit 3 Worksheet - User Access and System Integration
 
 ## Instructions
 

--- a/docs/psc/u4intro.md
+++ b/docs/psc/u4intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Bastion Hosts & Air-Gaps</h1>
-    </p>
-</div>
+# Bastion Hosts & Air-Gaps
 
 ## Overview
 

--- a/docs/psc/u4lab.md
+++ b/docs/psc/u4lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 4 Lab - Bastions</h1>
-    </p>
-</div>
+# Unit 4 Lab - Bastions
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u4ws.md
+++ b/docs/psc/u4ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 4 Worksheet - Bastions and Jailing Users</h1>
-    </p>
-</div>
+# Unit 4 Worksheet - Bastions and Jailing Users
 
 ## Instructions
 

--- a/docs/psc/u5intro.md
+++ b/docs/psc/u5intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Repos & Patching</h1>
-    </p>
-</div>
+# Repos & Patching
 
 ## Overview
 

--- a/docs/psc/u5lab.md
+++ b/docs/psc/u5lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 5 Lab - Repos and Patching</h1>
-    </p>
-</div>
+# Unit 5 Lab - Repos and Patching
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u5ws.md
+++ b/docs/psc/u5ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 5 Worksheet - Repos & Patching</h1>
-    </p>
-</div>
+# Unit 5 Worksheet - Repos & Patching
 
 ## Instructions
 

--- a/docs/psc/u6intro.md
+++ b/docs/psc/u6intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 6 - Monitoring and Parsing Logs</h1>
-    </p>
-</div>
+# Unit 6 - Monitoring and Parsing Logs
 
 ## Overview
 

--- a/docs/psc/u6lab.md
+++ b/docs/psc/u6lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 6 Lab - Monitoring and Parsing Logs</h1>
-    </p>
-</div>
+# Unit 6 Lab - Monitoring and Parsing Logs
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u6ws.md
+++ b/docs/psc/u6ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 6 Worksheet - Monitoring and Parsing Logs</h1>
-    </p>
-</div>
+# Unit 6 Worksheet - Monitoring and Parsing Logs
 
 ## Instructions
 

--- a/docs/psc/u7intro.md
+++ b/docs/psc/u7intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Monitoring and Alerting</h1>
-    </p>
-</div>
+# Monitoring and Alerting
 
 ## Overview
 

--- a/docs/psc/u7lab.md
+++ b/docs/psc/u7lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 7 Lab - Monitoring and Alerting</h1>
-    </p>
-</div>
+# Unit 7 Lab - Monitoring and Alerting
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u7ws.md
+++ b/docs/psc/u7ws.md
@@ -1,9 +1,4 @@
-<head>
-    <style> .flex-container { display: flex; align-items: center; gap: 20px; } </style>
-</head>
 <div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
         <h1>Unit 7 Worksheet - Monitoring and Alerting</h1>
     </p>
 </div>

--- a/docs/psc/u8intro.md
+++ b/docs/psc/u8intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 8 - Configuration Drift and Remediation</h1>
-    </p>
-</div>
+# Unit 8 - Configuration Drift and Remediation
 
 ## Overview
 

--- a/docs/psc/u8lab.md
+++ b/docs/psc/u8lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 8 Lab - Configuration Drift and Remediation</h1>
-    </p>
-</div>
+# Unit 8 Lab - Configuration Drift and Remediation
 
 > If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
 > the machine from the command line so that other students will have the intended environment.

--- a/docs/psc/u8ws.md
+++ b/docs/psc/u8ws.md
@@ -1,9 +1,4 @@
-<head>
-    <style> .flex-container { display: flex; align-items: center; gap: 20px; } </style>
-</head>
 <div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64">
-    <p>
         <h1>Unit 8 Worksheet - Configuration Drift and Remediation</h1>
     </p>
 </div>

--- a/docs/psc/u9intro.md
+++ b/docs/psc/u9intro.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 9 - Certificate and key madness</h1>
-    </p>
-</div>
+# Unit 9 - Certificate and key madness
 
 ## Overview
 

--- a/docs/psc/u9lab.md
+++ b/docs/psc/u9lab.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 9 Lab - Certificate and Key Madness</h1>
-    </p>
-</div>
+# Unit 9 Lab - Certificate and Key Madness
 
 ## Lab 🧪
 

--- a/docs/psc/u9ws.md
+++ b/docs/psc/u9ws.md
@@ -1,9 +1,4 @@
-<div class="flex-container">
-        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
-    <p>
-        <h1>Unit 9 Worksheet - Certificate and Key Madness</h1>
-    </p>
-</div>
+# Unit 9 Worksheet - Certificate and Key Madness
 
 ## Instructions
 


### PR DESCRIPTION
MkDocs cannot infer the title of the page in the nav from raw HTML headers, it requires markdown headers.

Closes #17