### PR TITLE
chore: Correct mdbook refs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,6 +66,22 @@ If any reviewer believes that the contribution may have been AI-generated, they
 may post a change request with a comment stating that they believe it came from AI.  
 If the reviewer is also a maintainer, they may reject the pull request.
 
+## Learning Markdown
+
+This project uses Markdown, which is a markup language used to create formatted
+text using a plaintext editor. Many developers and engineers have switched to 
+using Markdown to write technical documentation.  
+
+It's easy to learn, and any prospective contributor will be expected to 
+understand basic markdown syntax.  
+
+Below are some resources to get you started with Markdown:
+
+- [MkDocs Markdown Overview](https://www.mkdocs.org/user-guide/writing-your-docs/#writing-with-markdown)
+- [Commonmark Markdown Cheatsheet](https://commonmark.org/help/)
+- [Dillinger, a Web-based Markdown Editor and Previewer](https://dillinger.io/)
+- [HowToGeek: Brief Overview of Markdown](https://www.howtogeek.com/448323/what-is-markdown-and-how-do-you-use-it/)
+
 ## Signing your Git Commits with SSH
 
 Contributors who elect to contribute through the command line will need

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -436,23 +436,7 @@ before opening a pull request.
 Below are links to the necessary materials to build out the course templates:
 
 - Look over the [template pages wiki](https://github.com/ProfessionalLinuxUsersGroup/course-books/wiki), or directly here:
-  - Pages: [intro](https://github.com/ProfessionalLinuxUsersGroup/course-books/blob/main/ref/intro.md),
+  - Reference Pages: [intro](https://github.com/ProfessionalLinuxUsersGroup/course-books/blob/main/ref/intro.md),
     [bonus](https://github.com/ProfessionalLinuxUsersGroup/course-books/blob/main/ref/ub.md),
     [lab](https://github.com/ProfessionalLinuxUsersGroup/course-books/blob/main/ref/ulab.md),
     [worksheet](https://github.com/ProfessionalLinuxUsersGroup/course-books/blob/main/ref/uws.md)
-
-<!-- TODO: Implement wiki for ref material -->
-
-<!-- - Look over the [template pages wiki](https://github.com/ProfessionalLinuxUsersGroup/lac/wiki), or directly here: -->
-<!--   - Pages: [intro](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/intro.md), -->
-<!--     [bonus](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/ub.md), -->
-<!--     [lab](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/ulab.md), -->
-<!--     [worksheet](https://github.com/ProfessionalLinuxUsersGroup/lac/blob/main/ref/uws.md) -->
-<!---->
-<!-- Ancillary unit videos provided by Scott: -->
-<!---->
-<!-- - <https://www.youtube.com/watch?v=eHB8WKWz2eQ&list=PLyuZ_vuAWmprPIqsG11yoUG49Z5dE5TDu> -->
-<!---->
-<!-- PDF and docs directly related to each Unit of the course: -->
-<!---->
-<!-- - <https://discord.com/channels/611027490848374811/1098309490681598072> -->

--- a/docs/lac/syllabus.md
+++ b/docs/lac/syllabus.md
@@ -10,7 +10,7 @@ instructional materials produce by Scott Champine (het_tanis).
 
 The content is version controlled with Git and stored here: <https://github.com/ProfessionalLinuxUsersGroup/course-books>
 
-Furthermore, the book has been built with mdbook for ease of navigation. Be sure to try the search functionality.
+Furthermore, the book has been built with MkDocs for ease of navigation. Be sure to try the search functionality.
 
 **Course Description:**
 

--- a/docs/pcae/u1ws.md
+++ b/docs/pcae/u1ws.md
@@ -24,18 +24,16 @@ could be transposed to a `.md` file.
 
 ### Unit 1 Recording
 
-Coming soon.
-
-<!-- <iframe -->
-<!--     style="width: 100%; height: 100%; border: none; -->
-<!--     aspect-ratio: 16/9; border-radius: 1rem; background:black" -->
-<!--     src="PLACEHOLDER: Unit Embed Link" -->
-<!--     title="Automation Unit 1: Automation Tools - Lecure Recording" -->
-<!--     frameborder="0" -->
-<!--     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" -->
-<!--     referrerpolicy="strict-origin-when-cross-origin" -->
-<!--     allowfullscreen> -->
-<!-- </iframe> -->
+<iframe
+    style="width: 100%; height: 100%; border: none;
+    aspect-ratio: 16/9; border-radius: 1rem; background:black"
+    src="https://www.youtube.com/embed/wyVhGtFFYIQ?si=6-SPB7mVJL4LcIMV"
+    title="Automation Unit 1: Automation Tools - Lecure Recording"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+</iframe>
 
 #### Discussion Post #1
 

--- a/docs/psc/syllabus.md
+++ b/docs/psc/syllabus.md
@@ -8,9 +8,9 @@ Contains all materials pertaining to the course including links to external reso
 It has been put together with care by a number of ProLUG group members referencing original
 instructional materials produced by Scott Champine (Het Tanis).
 
-The content is version controlled with Git and stored here: <https://github.com/ProfessionalLinuxUsersGroup/psc/>
+The content is version controlled with Git and stored here: <https://github.com/ProfessionalLinuxUsersGroup/course-books/>
 
-Furthermore, the book has been built with mdbook for ease of navigation. Be sure to try the search functionality.
+Furthermore, the book has been built with MkDocs for ease of navigation. Be sure to try the search functionality.
 
 ### Course Description
 

--- a/scripts/generate-resources
+++ b/scripts/generate-resources
@@ -4,7 +4,7 @@
 #          FILE:  generate-resources
 #
 #         USAGE:  ./generate-resources
-#                 To be run from the root directory of the ProLUG course mdBook
+#                 To be run from the root directory of the ProLUG course MkDocs
 #                 project.  
 #
 #   DESCRIPTION:  This script generates a list of all external resources used in a


### PR DESCRIPTION
Change all references to mdBook to MkDocs.

Correct the link in the psc syllabus that points to the
mdBook repository.

Resolves #31 and resolves #35

Clean up comments on wiki in `contributing.md`, updated wiki 
pages accordingly (#23)

feat(pcae): Add automation unit 1 lecture recording

Additionally added a section on learning basic markdown in `contributing.md` with some links to external resources.