### PR TITLE
fix: Remove newlines before indented code blocks

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -103,7 +103,6 @@ Outside of system packages all files will be localized to the `/root/course-book
 on the container or machine.
 
 === "APT"
-
     ```bash linenums="1"
     #!/bin/bash
     apt-get update && apt-get -y install git python3-full hostname apache2
@@ -115,7 +114,6 @@ on the container or machine.
     ```
 
 === "DNF"
-
     ```bash linenums="1"
     #!/bin/bash
     dnf install -y httpd git python3 hostname httpd

--- a/docs/lac/u12lab.md
+++ b/docs/lac/u12lab.md
@@ -29,20 +29,17 @@ The lab has been provided for convenience below:
 ---
 
 1. Create a working directory
-
    ```bash linenums="1"
    mkdir lab_baseline
    cd lab_baseline
    ```
 
 2. Verify if `iostat` is available
-
    ```bash linenums="1"
    which iostat
    ```
 
    If it’s not there:
-
    ```bash linenums="1"
    # Find which package provides iostat
    dnf whatprovides iostat
@@ -58,13 +55,11 @@ The lab has been provided for convenience below:
    ```
 
 3. Verify if `stress` is available
-
    ```bash linenums="1"
    which stress
    ```
 
    If it’s not there:
-
    ```bash linenums="1"
    # Find which package provides stress
    dnf whatprovides stress
@@ -78,13 +73,11 @@ The lab has been provided for convenience below:
    ```
 
 4. Verify if `iperf3` is available
-
    ```bash linenums="1"
    which iperf3
    ```
 
    If it’s not there:
-
    ```bash linenums="1"
    # Find which package provides iperf3
    dnf whatprovides iperf
@@ -220,7 +213,6 @@ issues. No one cares what you think, they care what you can show, or prove.
   - Perform some basic tasks and get their completion times.
 
     - Writing/deleting 3000 empty files #modify as needed for your system
-
     ```bash linenums="1"
     # Speed: ~10s
     time for i in `seq 1 3000`; do touch testfile$i; done
@@ -236,14 +228,12 @@ issues. No one cares what you think, they care what you can show, or prove.
     ```
 
     - Testing processor speed
-
       ```bash linenums="1"
       time $(i=0; while (( i < 999999 )); do (( i ++ )); done)
       # if this takes your system under 10 seconds, add a 9
       ```
 
     - Alternate processor speed test
-
     ```bash linenums="1"
     time dd if=/dev/urandom bs=1024k count=20 | bzip2 -9 >> /dev/null
     ```
@@ -281,13 +271,11 @@ Make 3 different assumptions for how load may look on your system with the agent
 stress commands around them (examples):
 
 1. I assume no load on hdd, light load on processors
-
    ```bash linenums="1"
    while true; do stress --cpu 2 --io 4 --vm 2 --vm-bytes 128M --timeout 30; done #
    ```
 
 2. I assume low load on hdd, light load on processors
-
    ```bash linenums="1"
    while true; do stress --cpu 2-io 4 --vm 2 --vm-bytes 128M -d 1 --timeout 30; done
    ```

--- a/docs/lac/u3b.md
+++ b/docs/lac/u3b.md
@@ -30,21 +30,18 @@ iostat -dx 1
 ### Fix
 
 1. Identify and stop unnecessary high I/O processes:
-
    ```bash linenums="1"
    # Forcefully terminate a process (use with caution)
    kill -9 <PID>
    ```
 
 2. Optimize filesystem writes (for ext4):
-
    ```bash linenums="1"
    # Enable writeback mode for better performance
    tune2fs -o journal_data_writeback /dev/sdX
    ```
 
 3. Reduce excessive metadata writes:
-
    ```bash linenums="1"
    # Disable access time updates and set commit interval
    mount -o noatime,commit=60 /mnt/data
@@ -80,14 +77,12 @@ du -ahx / | sort -rh | head -20
 ### Fix
 
 1. Find and remove large unnecessary files:
-
    ```bash linenums="1"
    # Remove specific log file
    rm -f /var/log/large_old_log.log
    ```
 
 2. Truncate logs safely without deleting them:
-
    ```bash linenums="1"
    # Clear log contents while preserving file
    truncate -s 0 /var/log/syslog
@@ -97,7 +92,6 @@ du -ahx / | sort -rh | head -20
    ```
 
 3. Expand disk space if using LVM:
-
    ```bash linenums="1"
    # Extend logical volume
    lvextend -L +10G /dev/examplegroup/lv_data
@@ -129,7 +123,6 @@ cat /etc/fstab
 ### Fix
 
 1. Manually remount the filesystem (if missing):
-
    ```bash linenums="1"
    # Remount all fstab entries
    mount -a
@@ -143,7 +136,6 @@ cat /etc/fstab
    ```
 
 3. If an LVM mount is missing after reboot, reactivate it:
-
    ```bash linenums="1"
    # Activate volume groups
    vgchange -ay
@@ -153,7 +145,6 @@ cat /etc/fstab
    ```
 
 4. For NFS issues, check connectivity and restart services:
-
    ```bash linenums="1"
    # Check NFS exports
    showmount -e <NFS_SERVER_IP>
@@ -184,7 +175,6 @@ xfs_repair -n /dev/sdX  # for XFS
 ### Fix
 
 1. Repair the filesystem (if unmounted):
-
    ```bash linenums="1"
    # Unmount first
    umount /dev/sdX
@@ -222,7 +212,6 @@ find . -type f | wc -l
 ### Fix
 
 1. Clean up temporary files:
-
    ```bash linenums="1"
    # Remove old files in /tmp
    rm -rf /tmp/*

--- a/docs/lac/u4lab.md
+++ b/docs/lac/u4lab.md
@@ -50,13 +50,11 @@ The lab has been provided for convenience below:
 #### Pre-Lab - Disk Speed tests
 
 1. Real quick check for a package that is useful.
-
    ```bash linenums="1"
    rpm -qa | grep -i iostat #should find nothing
    ```
 
 2. Let's find what provides iostat by looking in the YUM (we'll explore more in later lab)
-
    ```bash linenums="1"
    dnf whatprovides iostat
    ```
@@ -64,13 +62,11 @@ The lab has been provided for convenience below:
    - This should tell you that `sysstat` provides `iostat`.
 
 3. Let's check to see if we have it
-
    ```bash linenums="1"
    rpm -qa | grep -i sysstat
    ```
 
 4. If you don't, lets install it
-
    ```bash linenums="1"
    dnf install sysstat
    ```
@@ -95,7 +91,6 @@ The lab has been provided for convenience below:
 ---
 
 1. Gathering system information release and kernel information
-
    ```bash linenums="1"
    cat /etc/*release
    uname
@@ -104,13 +99,11 @@ The lab has been provided for convenience below:
    ```
 
    Run `man uname` to see what those options mean if you don't recognize the values
-
    ```bash linenums="1"
    rpm -qa | grep -i kernel
    ```
 
    What is your kernel number? Highlight it (copy in putty)
-
    ```bash linenums="1"
    rpm -qi <kernel from earlier>
    ```
@@ -149,7 +142,6 @@ pvs # What system are we running if we have physical volumes?
   ```
 
 3. Check the amount of RAM
-
    ```bash linenums="1"
    cat /proc/meminfo
    free
@@ -180,7 +172,6 @@ iostat -c 2 5 # Don't break this, just wait. What did this do differently? Why m
 Does this look familiar to what we did earlier with `iostat`?
 
 5. Check the system uptime
-
    ```bash linenums="1"
    uptime
    man uptime
@@ -190,14 +181,12 @@ Does this look familiar to what we did earlier with `iostat`?
    Referencing this server, do you think it is under high load? Why or why not?
 
 6. Check who has recently logged into the server and who is currently in
-
    ```bash linenums="1"
    last
    ```
 
    Last is a command that outputs backwards. (Top is most recent).
    So it is less than useful without using the more command.
-
    ```bash linenums="1"
    last | more
    ```
@@ -211,7 +200,6 @@ Does this look familiar to what we did earlier with `iostat`?
      How many other users are on this system? What does the `pts/0` mean on Google?
 
 7. Check running processes and services
-
    ```bash linenums="1"
    ps -aux | more
    ps -ef | more
@@ -242,7 +230,6 @@ Sar can also be run interactively. Run the command `yum whatprovides sar` and yo
 `sysstat` package. You may have guessed that sar runs almost exactly like `iostat`.
 
 - Try the same commands from earlier, but with their interactive information:
-
   ```bash linenums="1"
   sar 2  # Ctrl+C to break
   sar 2 5
@@ -268,7 +255,6 @@ from a server, you'd have to output it to a file that is readable.
 You could do something like this:
 
 - Gather information and move to the right location
-
   ```bash linenums="1"
   cd /var/log/sa
   pwd
@@ -278,25 +264,21 @@ You could do something like this:
   We know the files we want are in this directory and all look like this `sa*`
 
 - Build a loop against that list of files
-
   ```bash linenums="1"
   for file in `ls /var/log/sa/sa??`; do echo "reading this file $file"; done
   ```
 
 - Execute that loop with the output command of sar instead of just saying the filename
-
   ```bash linenums="1"
   for file in `ls /var/log/sa/sa?? | sort -n`; do sar -f $file ; done
   ```
 
 - But that is too much scroll, so let's also send it to a file for later viewing
-
   ```bash linenums="1"
   for file in `ls /var/log/sa/sa?? | sort -n`; do sar -f $file | tee -a /tmp/sar_data_`hostname`; done
   ```
 
 - Let's verify that file is as long as we expect it to be:
-
   ```bash linenums="1"
   ls -l /tmp/sar_data*
   cat /tmp/sar_data_<yourhostname> | wc -l
@@ -369,19 +351,16 @@ minute through all hours, of every day, of every month.
 We could also have done some other things:
 
 - Every 2 minutes (divisible by any number you need):
-
   ```bash linenums="1"
   */2 * * * *
   ```
 
 - The first and 31st minute of each hour:
-
   ```bash linenums="1"
   1,31 * * * *
   ```
 
 - The first minute of every 4th hour:
-
   ```bash linenums="1"
   1 */4 * * *
   ```

--- a/docs/lac/u5lab.md
+++ b/docs/lac/u5lab.md
@@ -82,7 +82,6 @@ There are 4 files that comprise of the shadow password suite. We'll investigate 
 how they secure the system. The four files are `/etc/passwd`, `/etc/group`, `/etc/shadow`, and `/etc/gshadow`.
 
 1. Look at each of the files and see if you can determine some basic information about them
-
    ```bash linenums="1"
    more /etc/passwd
    more /etc/group
@@ -91,13 +90,11 @@ how they secure the system. The four files are `/etc/passwd`, `/etc/group`, `/et
    ```
 
    There is one other file you may want to become familiar with:
-
    ```bash linenums="1"
    more /etc/login.defs
    ```
 
    Check the file permissions:
-
    ```bash linenums="1"
    ls -l /etc/passwd
    ```
@@ -144,7 +141,6 @@ Your `/etc/login.defs` file is default and contains a lot of the values that con
 work
 
 5. Creating users
-
    ```bash linenums="1"
    useradd user1
    useradd user2
@@ -152,7 +148,6 @@ work
    ```
 
    Do a quick check on our main files:
-
    ```bash linenums="1"
    tail -5 /etc/passwd
    tail -5 /etc/shadow
@@ -160,7 +155,6 @@ work
 
    What `UID` and `GID` were each of these given? Do they match up?
    Verify your users all have home directories. Where would you check this?
-
    ```bash linenums="1"
    ls /home
    ```
@@ -168,20 +162,17 @@ work
    Your users `/home/<username>` directories have hidden files that were all pulled from a
    directory called `/etc/skel`. If you wanted to test this and verify you might do something like
    this:
-
    ```bash linenums="1"
    cd /etc/skel
    vi .bashrc
    ```
 
    Use `vi` commands to add the line:
-
    ```bash linenums="1"
    alias dinosaur='echo "Rarw"'
    ```
 
    Your file should now look like this:
-
    ```bash linenums="1"
    # .bashrc
    # Source global definitions
@@ -195,7 +186,6 @@ work
    ```
 
    Save the file with `:wq`.
-
    ```bash linenums="1"
    useradd user4
    su - user4
@@ -209,7 +199,6 @@ work
 
    We can test this with the same steps on an existing user.
    Pick an existing user and verify they don't have that command
-
    ```bash linenums="1"
    su - user1
    dinosaur # Command not found
@@ -217,7 +206,6 @@ work
    ```
 
    Then, as root:
-
    ```bash linenums="1"
    cd /home/user1
    mkdir old_dot_files
@@ -230,7 +218,6 @@ work
 6. Creating groups
    From our `/etc/login.defs` we can see that the default range for UIDs on this system, when created by
    `useradd` are:
-
    ```bash linenums="1"
    UID_MIN 1000
    UID_MAX 60000
@@ -239,7 +226,6 @@ work
    So an easy way to make sure that we don't get confused on our group numbering is to ensure we create
    groups outside of that range.
    This isn't required, but can save you headache in the future.
-
    ```bash linenums="1"
    groupadd -g 60001 project
    tail -5 /etc/group
@@ -247,7 +233,6 @@ work
 
    You can also make groups the old fashioned way by putting a line right into the `/etc/group` file.  
    Try this:
-
    ```bash linenums="1"
    vi /etc/group
    ```
@@ -257,21 +242,18 @@ work
    - Add `project2:x:60002:user4`
    - Hit `Esc`
    - `:wq!` to write quit the file explicit force because it's a read only file.
-
    ```bash linenums="1"
    id user 4 # Should now see the project2 in the user's groups
    ```
 
 7. Modifying or deleting users
    So maybe now we need to move our users into that group.
-
    ```bash linenums="1"
    usermod -G project user4
    tail -f /etc/group # Should see user4 in the group
    ```
 
    But, maybe we want to add more users and we want to just put them in there:
-
    ```bash linenums="1"
    vi /etc/group
    ```
@@ -282,7 +264,6 @@ work
    - Hit `Esc`.
    - `:wq` to save and exit.  
      Verify your users are in the group now
-
    ```bash linenums="1"
    id user4
    id user1
@@ -295,7 +276,6 @@ work
 
    Currently we have `user1,2,4` belonging to group `project` but not `user3`. So we will verify these
    permissions are enforced by the filesystem.
-
    ```bash linenums="1"
    mkdir /project
    ls -ld /project
@@ -308,7 +288,6 @@ work
    You've also given group `project` users the ability to write into your directory.
    Everyone can still read from your directory.
    Check permissions with users:
-
    ```bash linenums="1"
    su - user1
    cd /project
@@ -322,13 +301,11 @@ work
 
    Anyone not in the `project` group doesn't have permissions to write a file into that directory.
    Now, as the root user:
-
    ```bash linenums="1"
    chmod 770 /project
    ```
 
    Check permissions with users:
-
    ```bash linenums="1"
    su - user1
    cd /project

--- a/docs/lac/u6lab.md
+++ b/docs/lac/u6lab.md
@@ -71,13 +71,11 @@ Browsers sometimes like to format characters in a way that doesn't always play n
 A very important thing to note before starting this lab. You’re connected into that server on ssh via port 22. If you do anything to lockout **port 22** in this lab, you will be blocked from that connection and we’ll have to reset it.
 
 1. Check firewall status
-
    ```bash linenums="1"
    systemctl status firewalld
    ```
 
    Example Output:
-
    ```bash linenums="1"
    firewalld.service - firewalld - dynamic firewall daemon
    Loaded: loaded (/usr/lib/systemd/system/firewalld.service; enabled; vendor preset: enabled)
@@ -260,13 +258,11 @@ public
 We can be even more granular with our ports and services. We can block or allow services by port number, or we can assign port numbers to a service name and then block or allow those service names.
 
 1. List all services assigned in firewalld
-
    ```bash linenums="1"
    firewall-cmd --get-services
    ```
 
    Example Output:
-
    ```bash linenums="1"
    RH-Satellite-6 amanda-client bacula bacula-client dhcp dhcpv6 dhcpv6-client dns freeipa-ldap freeipa-ldaps freeipa-replication ftp high-availability http https imaps ipp ipp-client ipsec iscsi-target kerberos kpasswd ldap ldaps libvirt libvirt-tls mdns mountd ms-wbt mysql nfs ntp openvpn pmcd pmproxy pmwebapi pmwebapis pop3s postgresql proxy-dhcp radius rpc-bind rsyncd samba samba-client smtp ssh telnet tftp tftp-client transmission-client vdsm vnc-server wbem-https
    ```
@@ -274,13 +270,11 @@ We can be even more granular with our ports and services. We can block or allow 
    This next part is just to show you where the service definitions exist. They are simple xml format and can easily be manipulated or changed to make new services. This would require a restart of the firewalld service to re-read this directory.
 
    Next Command:
-
    ```bash linenums="1"
    ls /usr/lib/firewalld/services/
    ```
 
    Example Output:
-
    ```bash linenums="1"
    amanda-client.xml        iscsi-target.xml  pop3s.xml
    bacula-client.xml        kerberos.xml      postgresql.xml
@@ -303,13 +297,11 @@ We can be even more granular with our ports and services. We can block or allow 
    ```
 
    Next Command:
-
    ```bash linenums="1"
    cat /usr/lib/firewalld/services/http.xml
    ```
 
    Example Output:
-
    ```bash linenums="1"
    <?xml version="1.0" encoding="utf-8"?>
    <service>
@@ -322,25 +314,21 @@ We can be even more granular with our ports and services. We can block or allow 
 2. Adding a service or port to a zone
 
    Ensuring we are working on a public zone
-
    ```bash linenums="1"
    firewall-cmd --set-default-zone=public
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Listing Services
-
    ```bash linenums="1"
    firewall-cmd --list-services
    ```
 
    Example Ouput:
-
    ```bash linenums="1"
    dhcpv6-client ssh
    ```
@@ -348,85 +336,71 @@ We can be even more granular with our ports and services. We can block or allow 
    **Note:** We have 2 services
 
    Permanently adding a service with the `--permanent` switch
-
    ```bash linenums="1"
    firewall-cmd --permanent --add-service ftp
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Reloading
-
    ```bash linenums="1"
    firewall-cmd --reload
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Verifying we are in the correct **Zone**
-
    ```bash linenums="1"
    firewall-cmd --get-default-zone
    ```
 
    Example Output:
-
    ```bash linenums="1"
    public
    ```
 
    Verifying that we have successfully added the **FTP** service
-
    ```bash linenums="1"
    firewall-cmd --list-services
    ```
 
    Example Output:
-
    ```bash linenums="1"
    dhcpv6-client ftp ssh
    ```
 
    Alternatively, we can do almost the same thing but not use a defined service name. If I just want to allow port 1147 through for TCP traffic, it is very simple as well.
-
    ```bash linenums="1"
    firewall-cmd --permanent --add-port=1147/tcp
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Reloading once again
-
    ```bash linenums="1"
    firewall-cmd --reload
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Listing open ports now
-
    ```bash linenums="1"
    firewall-cmd --list-ports
    ```
 
    Example Output:
-
    ```bash linenums="1"
    1147/tcp
    ```
@@ -436,55 +410,46 @@ We can be even more granular with our ports and services. We can block or allow 
    To remove those values and permanently fix the configuration back we simply use remove.
 
    Firstly, we will permanently remove ftp service
-
    ```bash linenums="1"
    firewall-cmd --permanent --remove-service=ftp
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Then we will permanently remove the ports
-
    ```bash linenums="1"
    firewall-cmd --permanent --remove-port=1147/tcp
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Now lets do a reload
-
    ```bash linenums="1"
    firewall-cmd --reload
    ```
 
    Example Output:
-
    ```bash linenums="1"
    success
    ```
 
    Now we can list services again to confirm our work
-
    ```bash linenums="1"
    firewall-cmd --list-services
    ```
 
    Example Output:
-
    ```bash linenums="1"
    dhcpv6-client ssh
    ```
 
    Now we can list ports
-
    ```bash linenums="1"
    firewall-cmd --list-ports
    ```

--- a/docs/lac/u7b.md
+++ b/docs/lac/u7b.md
@@ -70,19 +70,16 @@ Let's say you suspect something has been changed or tampered with.
 Let's get all files from a package.  
 
 - Run `rpm -ql` to list the files that were installed with a package:
-
   ```bash linenums="1"
   rpm -ql openssh-server
   ```
 
 - Now pick one file and manually generate its sha256 hash:
-
   ```bash linenums="1"
   sha256sum /usr/sbin/sshd
   ```
 
 - Download the original `.rpm` package to compare its hash.
-
   ```bash linenums="1"
   dnf download openssh-server
   ```
@@ -91,20 +88,17 @@ Let's get all files from a package.
   - These `.rpm` packages are not stored on the system by default.
 
 - You can inspect the file of your choice with `rpm -qp --dump`:
-
   ```bash linenums="1"
   rpm -qp --dump openssh-server*.rpm | grep ^/usr/sbin/sshd
   ```
 
   This will output a bunch of information about the file.  
   The `sha256` hash will be in the fourth column, so we can use `awk` to extract that:
-
   ```bash linenums="1"
   rpm -qp --dump openssh-server*.rpm | grep ^/usr/sbin/sshd | awk '{print $4}'
   ```
 
 - Compare your version's hash to the original RPM file's hash:
-
   ```bash linenums="1"
   sha256sum /usr/sbin/sshd
   ```
@@ -121,7 +115,6 @@ If the hashes are different, the file has been modified.
    ```
    - This will verify every file from every package and report anything suspicious.
 1. Narrow the scope. Only show actual modified files:
-
    ```bash linenums="1"
    rpm -Va | grep -v '^..5'
    ```
@@ -130,7 +123,6 @@ If the hashes are different, the file has been modified.
    - You’ll now see files where size, mode, owner, or timestamp changed — higher confidence indicators of real change.
 
 1. Investigate a suspicious result. If you see something like:
-
    ```bash linenums="1"
    .M....... c /etc/ssh/sshd_config
    ```
@@ -141,7 +133,6 @@ If the hashes are different, the file has been modified.
    - It's a config file (`c`).
 
 1. Check the file in question:
-
    ```bash linenums="1"
    ls -l /etc/ssh/sshd_config
    ```

--- a/docs/psc/u1lab.md
+++ b/docs/psc/u1lab.md
@@ -97,7 +97,6 @@ ss -ntulp | grep 3306
     - Is it set properly on your system?
 
     Connect to MariaDB locally.
-
     ```bash linenums="1"
     mysql
     ```

--- a/docs/psc/u5lab.md
+++ b/docs/psc/u5lab.md
@@ -64,7 +64,6 @@ run their own repo on their network.
     - What file is fixed for all of them to be remediated?
 
 2. Install httpd on your Hammer server
-
    ```bash linenums="1"
    systemctl stop wwclient
    dnf install -y httpd


### PR DESCRIPTION
This is not a full comprehensive fix for #108 but it does fix a **lot** of them.  
We will still need to go over the cases in which there are regular lines of text indented after a newline after a list item. But this handles the code blocks.  

Used a script for this one. It was a fun one to write. I'll admit it's a little messy.
```bash
#!/bin/bash
shopt -s globstar

declare -a DELETE_LINES=()

for file in **/*.md; do
    # format as 'line:N' where N is line num to delete
    IFS=$'\n' read -r -d '' -a DELETE_LINES < <(perl -ne '
    my $dpattern = qr/^\s+(?:```bash)/;
    print "line:" . ($.-1) . "\n" if (m/$dpattern/ && $prev =~ /^\n/);
    $prev = $_;
    ' "$file";)
    [[ -n "${DELETE_LINES[*]}" ]] || continue

    # Reverse list of lines so that the other targeted lines don't shift inplace
    IFS=$'\n' read -r -d '' -a DELETE_LINES < <(
        printf "%s\n" "${DELETE_LINES[@]##*:}" | tac
    )
    printf "File: %s\n" "$file"
    printf "Sorted: %s\n" "${DELETE_LINES[@]}"
    
    for l in "${DELETE_LINES[@]}"; do
        printf "Deleting line: %s in file: %s\n" "${l##*:}" "${file}"
        # sed "566d" "docs/lac/u6lab.md"
        sed -i "${l##*:}d" "${file}"
    done
done
```
Deletion needed to happen from the highest number down. When doing them in order, all subsequent lines shifted down by one and the line numbers were no longer accurate. Reversed them and it worked as intended.