### PR TITLE
fix: format terms/defs, remove extraneous section, update nav

### DIFF
--- a/docs/pcae/u3intro.md
+++ b/docs/pcae/u3intro.md
@@ -7,10 +7,6 @@ This unit describes best practices for inventory management. It will clarify det
 
 We learn that a good inventory is complete, accurate and properly formatted.  Inventories must use consistent identifiers of the same type such as IP vs FQDN values.  The semi-structured nature of our inventory must be readable and properly formatted for use by our tool of choice (e.g. bash, python, ansible).
 
-### What is the skill/tech/concept we are dealing with?
-
-This unit continues to address the course objective to maintain inventories of systems for automation activities.  
-
 ## Learning Objectives
 
 1. Inventory Sources
@@ -37,9 +33,11 @@ This unit continues to address the course objective to maintain inventories of s
 
 ## Key Terms and Definitions
 
-Flat files  Just a list of servers or a basic list of tab/space separated values  
-IP address  Internet Protocol address   [RFC 1918] 
-FQDN        Fully Qualified Domain Name [RFC 1034] (note: RFC 1035 and many later updates)
-CSV         Comma Separated Values      [RFC 4180] 
-JSON        JavaScript Object Notation  [RFC 8259] (note: language independent)
-YAML        Yet Another Markup Language [RFC 9512] (note: language independent)
+|Terms||||
+|:------------------:|:------------------:|:------------------:|:------------------:|
+|**Flat files**|Just a list of servers or a basic list of tab/space separated values|||
+|**IP address**|Internet Protocol address|[RFC 1918]||
+|**FQDN**|Fully Qualified Domain Name|[RFC 1034]|(note: RFC 1035 and many later updates)|
+|**CSV**|Comma Separated Values|[RFC 4180]||
+|**JSON**|JavaScript Object Notation|[RFC 8259]|(note: language independent)|
+|**YAML**|Yet Another Markup Language|[RFC 9512]|(note: language independent)|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,7 +189,7 @@ nav:
       - Worksheet: pcae/u2ws.md
       - Lab: pcae/u2lab.md
     - Unit 3 - Creating && Using Inventories:
-    #   - Intro: pcae/u3intro.md
+      - Intro: pcae/u3intro.md
       - Worksheet: pcae/u3ws.md
       - Lab: pcae/u3lab.md
     - Unit 4 - Admin Commands && Ad-Hoc Commands:


### PR DESCRIPTION
- remove 'What is the skill/tech/concept we are dealing with?' section
- port key terms and definitions format from LAC
- add intro to mkdocs.yml nav