### PR TITLE
feat: add arg to append failed links to ignoredlinks.txt

### DIFF
--- a/scripts/link-storage/ignoredlinks.txt
+++ b/scripts/link-storage/ignoredlinks.txt
@@ -1,6 +1,9 @@
 http://dl.rockylinux.org/$contentdir/$releasever/BaseOS/$basearch/os/
 http://hammer25/repo/AppStream/
 http://hammer25/repo/BaseOS/
+http://ns.adobe.com/pdf/1.3/
+http://ns.adobe.com/xap/1.0/
+http://ns.adobe.com/xap/1.0/mm/
 https://aws.amazon.com/blogs/security/logging
 https://discord.com/api/webhooks/your_webhook_url
 https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_RHEL_9_V2R3_STIG_Ansible.zip

--- a/scripts/link-storage/successfullinks.txt
+++ b/scripts/link-storage/successfullinks.txt
@@ -12,6 +12,8 @@ http://www.w3.org/1999/02/22-rdf-syntax-ns
 https://ProLUG.org/
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index
 https://aide.github.io/
+https://apptainer.org/docs/user/latest/
+https://apptainer.org/docs/user/latest/introduction.html#why-use-apptainer
 https://attack.mitre.org/
 https://aws.amazon.com/blogs/big-data/tag/amazon-msk/
 https://aws.amazon.com/blogs/security/logging-strategies-for-security-incident-response/
@@ -23,6 +25,12 @@ https://ciq.com/blog/demystifying-and-troubleshooting-name-resolution-in-rocky-l
 https://cli.github.com/
 https://commonmark.org/help/
 https://csrc.nist.gov/projects/risk-management/about-rmf
+https://developer.hashicorp.com/packer/docs/intro
+https://developer.hashicorp.com/packer/tutorials/cloud-production/github-actions
+https://developer.hashicorp.com/packer/tutorials/docker-get-started/docker-get-started-provision
+https://developer.hashicorp.com/terraform/language/providers
+https://developer.hashicorp.com/terraform/tutorials/docker-get-started
+https://developer.hashicorp.com/tutorials/library?product=packer&edition=open_source
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/400
 https://developers.cloudflare.com/waf/get-started/
 https://devhints.io/bash
@@ -242,6 +250,8 @@ https://squidfunk.github.io/mkdocs-material/getting-started/
 https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types
 https://sre.google/books/
 https://sre.google/sre-book/monitoring-distributed-systems/
+https://sre.google/sre-book/release-engineering/
+https://sre.google/workbook/canarying-releases/
 https://sre.google/workbook/implementing-slos/
 https://sre.google/workbook/monitoring/
 https://tldp.org/LDP/Bash-Beginners-Guide/html/chap_01.html
@@ -321,6 +331,7 @@ https://www.youtube.com/embed/wCVj3qeLTMg?si=ozEReY_17DOyjUAv
 https://www.youtube.com/embed/wyVhGtFFYIQ?si=6-SPB7mVJL4LcIMV
 https://www.youtube.com/embed/x1kgXOWv-eM
 https://www.youtube.com/embed/xLv7CIJD6UI
+https://www.youtube.com/playlist?list=PLyuZ_vuAWmpoiB5_fo9zXd_leFwzfbA5o
 https://www.youtube.com/watch?v=54VgGHr99Qg
 https://www.youtube.com/watch?v=alcsTPQsruM&list=PLyuZ_vuAWmpqHEm-Js2gZleKzUY5uBWcM
 https://www.youtube.com/watch?v=d8XtNXutVto

--- a/scripts/link-validate.py
+++ b/scripts/link-validate.py
@@ -6,20 +6,19 @@
 # be added to ignoredlinks.txt. Additionally attempts to store
 # validated links in flat file to reduce subsequent runtimes
 
-# Must be called from root of github repo directory
 # Not intended for use in runner builds for the time being
 # Delete or empty successfullinks.txt for now to retest all links
 
 # USE RESPONSIBLY
 
+import argparse
 import re
 import sys
-import argparse
-import urllib.request
 import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 RED = "\033[91m"
 GREEN = "\033[92m"
@@ -36,82 +35,97 @@ REGEX = r"(?<!\[)\bhttps?://\S+\b/?"
 PATTERN = re.compile(REGEX)
 
 FAILED_REPORT = f"failed_links.{datetime.now().strftime('%Y-%m-%d')}"
-STORAGE = 'scripts/link-storage/successfullinks.txt'
-IGNORED = 'scripts/link-storage/ignoredlinks.txt'
+STORAGE = "scripts/link-storage/successfullinks.txt"
+IGNORED = "scripts/link-storage/ignoredlinks.txt"
 
 
 def cli_args():
-    """ Provide CLI options to skip validated or ignored link storage and skip URL validation
-        Create and return argparse object with configured argument attributes
+    """Provide CLI options to skip validated or ignored link storage and skip URL validation
+    Create and return argparse object with configured argument attributes
     """
     args_parser = argparse.ArgumentParser(
-        description= \
-        'Attempts to resolve any http(s) URL links found recursively from execution path.',
+        description="Attempts to resolve any http(s) URL links found recursively from execution path.",
     )
     args_parser.add_argument(
-        '-s', '--skip-storage',
-        action='store_true',
-        help='Skip inclusion of stored successfullinks.txt URLs',
-        dest='skip_store'
+        "-s",
+        "--skip-storage",
+        action="store_true",
+        help="Skip inclusion of stored successfullinks.txt URLs",
+        dest="skip_store",
     )
     args_parser.add_argument(
-        '-i', '--skip-ignored',
-        action='store_true',
-        help='Skip inclusion of stored ignoredlinks.txt URLs',
-        dest='skip_ignore'
+        "-i",
+        "--skip-ignored",
+        action="store_true",
+        help="Skip inclusion of stored ignoredlinks.txt URLs",
+        dest="skip_ignore",
     )
     args_parser.add_argument(
-        '-r', '--build-storage',
-        action='store_true',
-        help='Build new successfullinks.txt file based on resolved links',
-        dest='build_storage'
+        "-r",
+        "--build-storage",
+        action="store_true",
+        help="Build new successfullinks.txt file based on resolved links",
+        dest="build_storage",
     )
     args_parser.add_argument(
-        '-b', '--build-ignored',
-        action='store_true',
-        help='Build new ignorelinks.txt file based on reported failed links',
-        dest='build_ignore'
+        "-b",
+        "--build-ignored",
+        action="store_true",
+        help="Build new ignorelinks.txt file based on reported failed links",
+        dest="build_ignore",
     )
     args_parser.add_argument(
-        '-n', '--no-validation',
-        action='store_true',
-        help='Skip validation of URLs and print default reporting to stdout',
-        dest='skip_validation'
+        "-a",
+        "--add-failed",
+        action="store_true",
+        help="Add failed links to ignorelinks.txt file",
+        dest="add_failed",
     )
     args_parser.add_argument(
-        '-d', '--directory',
+        "-n",
+        "--no-validation",
+        action="store_true",
+        help="Skip validation of URLs and print default reporting to stdout",
+        dest="skip_validation",
+    )
+    args_parser.add_argument(
+        "-d",
+        "--directory",
         type=str,
         default=Path.cwd(),
-        help='Aggregate links from a specified directory',
-        dest='directory'
+        help="Aggregate links from a specified directory",
+        dest="directory",
     )
 
     return args_parser
 
+
 def get_file_links(path):
     """Populate stored/ignored links from passed path or instantiate file from path if missing"""
     if Path(path).exists():
-        with open(path, 'r', encoding='utf-8') as f_stored:
+        with open(path, "r", encoding="utf-8") as f_stored:
             stored_links = [line.strip() for line in f_stored]
     else:
-        with open(path, 'w', encoding = 'utf-8'):
+        with open(path, "w", encoding="utf-8"):
             stored_links = []
 
     return stored_links
 
+
 def sort_file(path):
     """Sort files for stored and ignored links to reduce diffs"""
-    with open(path, 'r', encoding='utf-8') as f_pre:
+    with open(path, "r", encoding="utf-8") as f_pre:
         links = [line.strip() for line in f_pre]
         links.sort()
         if links:
-            with open(path, 'w', encoding='utf-8') as f_post:
+            with open(path, "w", encoding="utf-8") as f_post:
                 for line in links:
-                    f_post.writelines(f'{line}\n')
+                    f_post.writelines(f"{line}\n")
+
 
 def validate_link(matched_item):
-    """ Attempt to resolve link and return error or status code for processing
-        Utilizes user-agent headers to reduce false negative returns
+    """Attempt to resolve link and return error or status code for processing
+    Utilizes user-agent headers to reduce false negative returns
     """
     headers = {
         "User-Agent": (
@@ -126,27 +140,21 @@ def validate_link(matched_item):
     req = urllib.request.Request(matched_item["link"], headers=headers)
 
     try:
-        with urllib.request.urlopen(req, timeout = 7) as response:
-            if response.code >= 200 or response.code <=399:
+        with urllib.request.urlopen(req, timeout=7) as response:
+            if response.code >= 200 or response.code <= 399:
                 link_status = 0, response.status
             else:
-                print(
-                    f'{matched_item['link']}\n'
-                    f'\t- {RED}Unknown error{RESET}'
-                )
-                link_status = 1, 'Unknown Error'
-    except urllib.error.HTTPError as e:
-        link_status = 1, e
-    except urllib.error.URLError as e:
-        link_status = 1, e
-    except TimeoutError as e:
+                print(f"{matched_item['link']}\n" f"\t- {RED}Unknown error{RESET}")
+                link_status = 1, "Unknown Error"
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
         link_status = 1, e
 
     return link_status, matched_item
 
+
 def get_unique_links(stored, ignored, arg_path):
-    """ Aggregate URLs for link validation into dictionary for processing
-        Returns per file total and total unique links found into list for reporting
+    """Aggregate URLs for link validation into dictionary for processing
+    Returns per file total and total unique links found into list for reporting
     """
 
     stored_links = stored
@@ -156,19 +164,15 @@ def get_unique_links(stored, ignored, arg_path):
     unique_links = []
     file_matches = int(0)
     total_links = int(0)
-    link_item = {
-        "link": "",
-        "file": "",
-        "line": ""
-    }
-    for p in Path(arg_path).rglob('*'):
+    link_item = {"link": "", "file": "", "line": ""}
+
+    for p in Path(arg_path).rglob("*"):
         try:
-            if (p.is_file()
-                and p not in {
-                    Path(STORAGE),
-                    Path(IGNORED),
-                    Path(FAILED_REPORT)
-                }):
+            if p.is_file() and p not in {
+                Path(STORAGE),
+                Path(IGNORED),
+                Path(FAILED_REPORT),
+            }:
                 file_paths.append(p)
             else:
                 continue
@@ -177,27 +181,25 @@ def get_unique_links(stored, ignored, arg_path):
 
     for path in file_paths:
         try:
-            with open(path, 'r', encoding='utf-8') as f:
+            with open(path, "r", encoding="utf-8") as f:
                 contents = f.read().splitlines()
                 for i, line in enumerate(contents, 1):
                     str_match = PATTERN.search(line)
                     if str_match:
                         match = str_match.group(0)
-                        if '(' in match and 'localhost' not in match:
-                            split_match = match.split('/')
-                            if '(' in split_match[-1] and ')' not in split_match[-1]:
-                                split_match[-1] = split_match[-1] + ')'
-                                match = '/'.join(split_match)
-                        elif 'localhost' in match :
-                            match = ''
+                        # Some URLs have nested resource URIs with parenthesis
+                        # i.e: https://en.wikipedia.org/wiki/C_(programming_language)
+                        if "(" in match and "localhost" not in match:
+                            split_match = match.split("/")
+                            if "(" in split_match[-1] and ")" not in split_match[-1]:
+                                split_match[-1] = split_match[-1] + ")"
+                                match = "/".join(split_match)
+                        elif "localhost" in match:
+                            match = ""
                     else:
-                        match = ''
+                        match = ""
                     if match:
-                        link_item = {
-                            "link": match,
-                            "file": path,
-                            "line": i
-                        }
+                        link_item = {"link": match, "file": path, "line": i}
                         matched_links.append(link_item)
                         file_matches += 1
                 total_links += file_matches
@@ -205,20 +207,21 @@ def get_unique_links(stored, ignored, arg_path):
         except UnicodeDecodeError:
             pass
 
-    unique_links = list({i['link']:i for i in reversed(matched_links)}.values())
+    unique_links = list({i["link"]: i for i in reversed(matched_links)}.values())
 
     print(
-        f'Total links found: {ORANGE}{total_links}{RESET}\n'
-        f'Unique links: {GREEN}{len(unique_links)}{RESET}\n'
-        f'Filtering stored and ignored links...'
+        f"Total links found: {ORANGE}{total_links}{RESET}\n"
+        f"Unique links: {GREEN}{len(unique_links)}{RESET}\n"
+        f"Filtering stored and ignored links..."
     )
 
     if stored_links:
-        unique_links[:] = [d for d in unique_links if d['link'] not in stored_links]
+        unique_links[:] = [d for d in unique_links if d["link"] not in stored_links]
     if ignored_links:
-        unique_links[:] = [d for d in unique_links if d['link'] not in ignored_links]
+        unique_links[:] = [d for d in unique_links if d["link"] not in ignored_links]
 
     return unique_links
+
 
 def main():
     """The place we call home"""
@@ -232,11 +235,11 @@ def main():
         parser = cli_args().parse_args()
 
         if parser.build_ignore:
-            print('Ignored link storage has been reset...')
-            open(IGNORED, 'w', encoding='utf-8').close()
+            print("Ignored link storage has been reset...")
+            open(IGNORED, "w", encoding="utf-8").close()
         if parser.build_storage:
-            print('Successful link storage has been reset...')
-            open(STORAGE, 'w', encoding='utf-8').close()
+            print("Successful link storage has been reset...")
+            open(STORAGE, "w", encoding="utf-8").close()
         if parser.skip_store is False:
             storage_links = get_file_links(STORAGE)
         if parser.skip_ignore is False:
@@ -244,19 +247,19 @@ def main():
         if parser.directory and Path(parser.directory).exists():
             arg_path = parser.directory
         else:
-            print('Path may not exist\nExiting...')
+            print("Path may not exist\nExiting...")
             sys.exit(1)
 
         test_links = get_unique_links(storage_links, ignored_storage_links, arg_path)
 
         if test_links and parser.skip_validation is False:
-            print('Attempting to resolve links for testing...')
-            print(f'Links to test: {BLUE}{len(test_links)}{RESET}\nPlease wait...')
+            print("Attempting to resolve links for testing...")
+            print(f"Links to test: {BLUE}{len(test_links)}{RESET}\nPlease wait...")
             count = 0
             with ThreadPoolExecutor(max_workers=WORKER_COUNT) as executor:
                 futures = {
-                    executor.submit(validate_link, dict_item):
-                    dict_item for dict_item in test_links
+                    executor.submit(validate_link, dict_item): dict_item
+                    for dict_item in test_links
                 }
                 for future in as_completed(futures):
                     try:
@@ -267,21 +270,25 @@ def main():
                         elif link_status[0] == 0:
                             successful_links.append(link)
                             count += 1
-                        print(f"\rLinks tested: {ORANGE}{count}{RESET}", end="", flush=True)
+                        print(
+                            f"\rLinks tested: {ORANGE}{count}{RESET}",
+                            end="",
+                            flush=True,
+                        )
                     except Exception as e:
-                        print(f'{futures[future]} - Unexpected error: {e}')
+                        print(f"{futures[future]} - Unexpected error: {e}")
 
             print()
         if successful_links and parser.skip_store is False:
-            print('Appending successful links...')
-            with open(STORAGE, 'a', encoding='utf-8') as f_updated:
+            print("Appending successful links...")
+            with open(STORAGE, "a", encoding="utf-8") as f_updated:
                 [f_updated.writelines(f'{link["link"]}\n') for link in successful_links]
             sort_file(STORAGE)
 
         if failed_links and parser.skip_validation is False:
-            print(f'Failed Links: {RED}{len(failed_links)}{RESET}')
-            print(f'Writing report to {Path.cwd()}/{FAILED_REPORT}...')
-            with open(FAILED_REPORT, 'w', encoding='utf-8') as f_report:
+            print(f"Failed Links: {RED}{len(failed_links)}{RESET}")
+            print(f"Writing report to {Path.cwd()}/{FAILED_REPORT}...")
+            with open(FAILED_REPORT, "w", encoding="utf-8") as f_report:
                 [
                     f_report.writelines(
                         f'{link["link"]}'
@@ -292,17 +299,25 @@ def main():
                 ]
 
             if parser.build_ignore:
-                print('Building new ignoredlinks.txt file...')
-                with open(IGNORED, 'w', encoding='utf-8') as f_ignore:
+                print("Building new ignoredlinks.txt file...")
+                with open(IGNORED, "w", encoding="utf-8") as f_ignore:
                     [f_ignore.writelines(f'{link["link"]}\n') for link in failed_links]
                 sort_file(IGNORED)
 
+            if parser.add_failed and parser.build_ignore is False:
+                print("Appending failed links to ignoredlinks.txt file...")
+                with open(IGNORED, "a", encoding="utf-8") as f_ignore:
+                    [f_ignore.writelines(f'{link["link"]}\n') for link in failed_links]
+                sort_file(IGNORED)
+
+
         elif parser.skip_validation is True:
-            print('Skipped link validation!')
+            print("Skipped link validation!")
         else:
-            print('No failed links!')
+            print("No failed links!")
     except Exception as e:
         print(e)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
- general format ran against python script using isort/black
- add argument (-a, --add-failed) to easily append failed links, this should generally be used after validating links need to be ignored
- add new failed adobe metadata links to failed links file
- update successfullinks.txt with links from new labs and worksheets
- cleanup on exception structure for URL calls L:126